### PR TITLE
Expose MouseData and fix an issue with AsyncConcurrentQueue

### DIFF
--- a/src/EventHook/Helpers/AsyncConcurrentQueue.cs
+++ b/src/EventHook/Helpers/AsyncConcurrentQueue.cs
@@ -38,7 +38,7 @@ namespace EventHook.Helpers
 
             //signal 
             dequeueTaskLock.Wait();
-            dequeueTask.TrySetResult(true);
+            dequeueTask?.TrySetResult(true);
             dequeueTaskLock.Release();
 
         }

--- a/src/EventHook/Hooks/MouseHook.cs
+++ b/src/EventHook/Hooks/MouseHook.cs
@@ -11,6 +11,7 @@ namespace EventHook.Hooks
     {
         internal MouseMessages Message { get; set; }
         internal Point Point { get; set; }
+        internal uint MouseData { get; set; }
     }
 
     /// <summary>
@@ -25,7 +26,9 @@ namespace EventHook.Hooks
         WM_RBUTTONDOWN = 0x0204,
         WM_RBUTTONUP = 0x0205,
         WM_WHEELBUTTONDOWN = 0x207,
-        WM_WHEELBUTTONUP = 0x208
+        WM_WHEELBUTTONUP = 0x208,
+        WM_XBUTTONDOWN = 0x020B,
+        WM_XBUTTONUP = 0x020C
     }
 
     /// <summary>
@@ -94,7 +97,7 @@ namespace EventHook.Hooks
 
             hookStruct = (MSLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(MSLLHOOKSTRUCT));
 
-            MouseAction(null, new RawMouseEventArgs { Message = (MouseMessages)wParam, Point = hookStruct.pt });
+            MouseAction(null, new RawMouseEventArgs { Message = (MouseMessages)wParam, Point = hookStruct.pt, MouseData = hookStruct.mouseData });
 
             return CallNextHookEx(_hookId, nCode, wParam, lParam);
         }

--- a/src/EventHook/MouseWatcher.cs
+++ b/src/EventHook/MouseWatcher.cs
@@ -13,6 +13,7 @@ namespace EventHook
     {
         public MouseMessages Message { get; set; }
         public Point Point { get; set; }
+        public uint MouseData { get; set; }
     }
 
     /// <summary>
@@ -134,7 +135,7 @@ namespace EventHook
         /// <param name="kd"></param>
         private void KListener_KeyDown(RawMouseEventArgs kd)
         {
-            OnMouseInput?.Invoke(null, new MouseEventArgs { Message = kd.Message, Point = kd.Point });
+            OnMouseInput?.Invoke(null, new MouseEventArgs { Message = kd.Message, Point = kd.Point, MouseData = kd.MouseData });
         }
     }
 }


### PR DESCRIPTION
Hi,

first of all: nice work!

I've made some tweaks to enable users to hook back/forward mouse buttons. I've add XBUTTONUP/DOWN enums and exposed MouseData. MouseData contains the flag encoding what button was pressed.

You now can do the following:
```csharp
mouseWatcher.OnMouseInput += (s, e) =>
{
    if (e.Message == MouseMessages.WM_XBUTTONUP)
    {
        if (e.MouseData == 0x10000) GoBack();
        else if (e.MouseData == 0x20000) GoForward();
    }
};
```

I've also added a null check to `AsyncConcurrentQueue` as it had a race condition when `MouseWatcher.Start` is executing. Sometimes events are Enqueue'd in MListener before anyone is waiting for data.

Cheers,
Jabe